### PR TITLE
feat: マニフェスト一覧取得APIの実装

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -40,6 +40,7 @@ export async function createApp(kv?: Deno.Kv): Promise<Hono> {
 
   // APIエンドポイント
   app.post('/api/manifestos', ...manifestoHandlers.create);
+  app.get('/api/manifestos', manifestoHandlers.list);
 
   return app;
 }

--- a/src/repositories/manifesto.ts
+++ b/src/repositories/manifesto.ts
@@ -3,6 +3,7 @@ import type { Manifesto } from '../types/models/manifesto.ts';
 export type ManifestoRepository = {
   save(manifesto: Manifesto): Promise<void>;
   findById(id: string): Promise<Manifesto | null>;
+  findAll(): Promise<Manifesto[]>;
 };
 
 export function createManifestoRepository(kv: Deno.Kv): ManifestoRepository {
@@ -14,6 +15,11 @@ export function createManifestoRepository(kv: Deno.Kv): ManifestoRepository {
     async findById(id: string): Promise<Manifesto | null> {
       const result = await kv.get<Manifesto>(['manifestos', id]);
       return result.value;
+    },
+
+    async findAll(): Promise<Manifesto[]> {
+      const entries = await Array.fromAsync(kv.list<Manifesto>({ prefix: ['manifestos'] }));
+      return entries.map((entry) => entry.value);
     },
   };
 }

--- a/src/types/api/manifesto.ts
+++ b/src/types/api/manifesto.ts
@@ -1,3 +1,5 @@
+import type { Manifesto } from '../models/manifesto.ts';
+
 export type CreateManifestoRequest = {
   title: string;
   content: string;
@@ -10,4 +12,8 @@ export type CreateManifestoResponse = {
 
 export type ErrorResponse = {
   error: string;
+};
+
+export type ListManifestoResponse = {
+  manifestos: Manifesto[];
 };


### PR DESCRIPTION
## 概要

TDDアプローチに従ってマニフェスト一覧を取得するAPIを実装しました。
既存のアーキテクチャパターンを踏襲し、コードの一貫性を保っています。

## 関連Issue

## 変更内容

- `GET /api/manifestos` エンドポイントを追加
- `ManifestoRepository` に `findAll()` メソッドを追加（Deno KVのlistを使用）
- `ListManifestoResponse` 型を定義（既存の `Manifesto` 型を再利用）
- ハンドラーに `list` 機能を実装
- 認証はBearer tokenを必須としている

## 動作確認

- RED → GREEN → REFACTOR のTDDサイクルで開発
- Test Stepsを使用した階層的なテスト構造
- 空のリストを返すケースと保存済みデータを返すケースをテスト
- 全てのテストが通過することを確認

## チェックリスト

- [x] ビルドが通る
- [x] テストを追加/更新した（必要な場合）
- [x] 既存のテストが全て通る
- [ ] ドキュメントを更新した（必要な場合）
- [ ] 環境変数の変更がある場合は、README.mdを更新した

## スクリーンショット（UI変更がある場合）

<\!-- UI変更がある場合はスクリーンショットを添付してください -->
N/A

## その他

- コードレビューで指摘された改善点を反映済み
  - 重複した型定義を削除し、`Manifesto` 型を再利用
  - `findAll()` メソッドを `Array.fromAsync()` を使用してシンプルに実装
  - importを常にファイル先頭に配置

# CLAへの同意

- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai-volunteer/fact-checker/blob/main/CLA.md)に同意することが必須です。
  内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]"
  に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました